### PR TITLE
sortteam/HyKuFe#5 public dns list 예외처리

### DIFF
--- a/client/data_splitter.py
+++ b/client/data_splitter.py
@@ -40,7 +40,8 @@ def dataload_unittest(file_path):
 def main(args):
     public_dns = get_public_dns(region_name='ap-northeast-2',
                                 tag='type', value=['client'])
-    public_dns.remove('')
+    if '' in public_dns:
+        public_dns.remove('')
     num_instances = len(public_dns)
 
     transform = transforms.Compose([transforms.ToTensor(),
@@ -61,6 +62,7 @@ def main(args):
                             user='ubuntu',
                             connect_kwargs={"key_filename": args.key_path}
                             ) as c:
+                print(public_dns[k] + ' Data Send!')
                 c.put(file_path, '/tmp/data.pt')
 
 if __name__ == '__main__':


### PR DESCRIPTION
- [ansible/ec2.py](https://github.com/ansible/ansible/blob/devel/contrib/inventory/ec2.py)을 사용하면 가끔 public dns가 비어있는 null string이 list에 들어감.
- 따라서 이를 제거하는 코드 수정
```python
    if '' in public_dns:
        public_dns.remove('')
```